### PR TITLE
docker-compose and apihandler check

### DIFF
--- a/Kelburg_frontend/APIHandler.cs
+++ b/Kelburg_frontend/APIHandler.cs
@@ -64,7 +64,7 @@ public class TicketAPI : APIData
 
 public static class eTables
 {
-    private const string APIBaseUrl = "https://localhost:44306/api";
+    private const string APIBaseUrl = "http://10.133.51.102:8080/api";
 
     public static readonly BookingsAPI Bookings = new($"{APIBaseUrl}/Bookings");
     public static readonly CarsAPI HotelCars = new($"{APIBaseUrl}/HotelCars");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
-﻿services:
+﻿version: "3.8"
+
+services:
   kelburg_frontend:
-    image: kelburg_frontend
-    build:
-      context: .
-      dockerfile: Kelburg_frontend/Dockerfile
+    image: kelburg_frontend:latest
+    ports:
+      - "80:80"


### PR DESCRIPTION
This pull request includes updates to the API base URL and improvements to the `docker-compose.yml` configuration for better deployment and consistency. Below are the key changes:

### API Configuration Updates:
* Updated the `APIBaseUrl` in `eTables` from `https://localhost:44306/api` to `http://10.133.51.102:8080/api` to reflect the new server address. (`Kelburg_frontend/APIHandler.cs`, [Kelburg_frontend/APIHandler.csL67-R67](diffhunk://#diff-0aabf9c4efce402b62180fad3fde6b59ce3bc962e4bba12218abf09961e7babdL67-R67))

### Deployment Configuration Updates:
* Modified `docker-compose.yml` to specify version `3.8` and updated the `kelburg_frontend` service to use the `kelburg_frontend:latest` image. Additionally, added port mapping to expose the service on port 80. (`docker-compose.yml`, [docker-compose.ymlL1-R7](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1-R7))